### PR TITLE
Improve names for duplicated elements

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -437,7 +437,7 @@ def append_xml_elements(out_el, in_el, element_map, infile):
             postfix = ""
             postfix_num = 1
             while find_child(out_el, "element", { "name" : name + postfix }) != None:
-                postfix = str(postfix_num)
+                postfix = "_" + str(postfix_num)
                 postfix_num += 1
             name = name + postfix
 


### PR DESCRIPTION
When adding a elements with a name that already exists in the out file,
add an underline before the appended index.

This fixes a confusion when adding few inputs with names such as "R1" and
"R11". Before this commit it was hard to seperate between duplicated "R1"
and pre-existing "R11". Those names are used to identfy the components in
the output of some ULP scripts.